### PR TITLE
Reverting Setup README back to fork version

### DIFF
--- a/Exercise00-Setup/README.20230512.001.old
+++ b/Exercise00-Setup/README.20230512.001.old
@@ -8,19 +8,13 @@
 ### Deployment Steps
 Please follow the below steps to successfully deploy a Synapse workspace and its artifacts on your Azure subscription
 
-* Fork microsoft/AzureSynapseEndToEndDemo project to your local github account. Make sure to check "Copy the main branch only".
-
-    ![Forking](/Images/Forking.gif)
-
-* Once you fork the AzureSynapseEndToEndDemo project to your github account, please click on **Deploy to Azure** button to start the deployment
-
-    [![Deploy To Azure](/Images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2FAzureSynapseEndToEndDemo%2Fmain%2FARMTemplate%2Fazuredeploy.json)
+###     [![Deploy To Azure](/Images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2FAzureSynapseEndToEndDemo%2Fmain%2FARMTemplate%2Fazuredeploy.json)
 
 * **Deploy to Azure** button takes you to the https://ms.portal.azure.com/#create/Microsoft.Template webpage. Please provide subscription, resource group, region, storage account name, storage container name, workspace name, dedicated sql pool name, spark pool name, spark pool node size, sql administration username/password, sku (dedicated sql pool Data Warehouse Units), and github username parameter values.
 
     >:exclamation::point_right:**It's incredibly important that you write down all the values in the above step. Many will need to be supplied later as parameters.**
 
-    >*Note: The github username should be the target github account where you forked the project. Example: If https://github.com/microsoft/AzureSynapseEndToEndDemo is the github project url, then "microsoft" is github account name.*
+    >*Note: The github username should be the target github account. Example: If https://github.com/microsoft/AzureSynapseEndToEndDemo is the github project url, then "microsoft" is github account name.*
 
 * Click on the **Review + Create** button to trigger deployment validation. If deployment validation is successful, the single click deployment will deploy a Synapse Workspace, Dedicated SQL Pool, and Spark Pool. This deployment also enables git configuration so all the required artifacts for the end-to-end demo are committed to your user github project. This completes the Azure Synapse end-to-end code deployment step.
 

--- a/Exercise00-Setup/README.md
+++ b/Exercise00-Setup/README.md
@@ -8,13 +8,19 @@
 ### Deployment Steps
 Please follow the below steps to successfully deploy a Synapse workspace and its artifacts on your Azure subscription
 
-###     [![Deploy To Azure](/Images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2FAzureSynapseEndToEndDemo%2Fmain%2FARMTemplate%2Fazuredeploy.json)
+* Fork microsoft/AzureSynapseEndToEndDemo project to your local github account. Make sure to check "Copy the main branch only".
+
+    ![Forking](/Images/Forking.gif)
+
+* Once you fork the AzureSynapseEndToEndDemo project to your github account, please click on **Deploy to Azure** button to start the deployment
+
+    [![Deploy To Azure](/Images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2FAzureSynapseEndToEndDemo%2Fmain%2FARMTemplate%2Fazuredeploy.json)
 
 * **Deploy to Azure** button takes you to the https://ms.portal.azure.com/#create/Microsoft.Template webpage. Please provide subscription, resource group, region, storage account name, storage container name, workspace name, dedicated sql pool name, spark pool name, spark pool node size, sql administration username/password, sku (dedicated sql pool Data Warehouse Units), and github username parameter values.
 
     >:exclamation::point_right:**It's incredibly important that you write down all the values in the above step. Many will need to be supplied later as parameters.**
 
-    >*Note: The github username should be the target github account. Example: If https://github.com/microsoft/AzureSynapseEndToEndDemo is the github project url, then "microsoft" is github account name.*
+    >*Note: The github username should be the target github account where you forked the project. Example: If https://github.com/microsoft/AzureSynapseEndToEndDemo is the github project url, then "microsoft" is github account name.*
 
 * Click on the **Review + Create** button to trigger deployment validation. If deployment validation is successful, the single click deployment will deploy a Synapse Workspace, Dedicated SQL Pool, and Spark Pool. This deployment also enables git configuration so all the required artifacts for the end-to-end demo are committed to your user github project. This completes the Azure Synapse end-to-end code deployment step.
 

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ large sized Health Care sample data. You will learn how to ingest, process, and 
 * [Exercise 01 - Claims](Exercise01-Claims/README.md)
 * [Exercise 02 - Observations](Exercise02-Observations/README.md)
 * [Exercise 03 - Patients](Exercise03-Patients/README.md)
-* [Troubleshooting](Troubleshooting/Readme.md)
+* [Troubleshooting](Troubleshooting/README.md)


### PR DESCRIPTION
Reverting Setup README back to fork version. Keeping the existing README (without version) as a backup with current date. Updating the file name upper case for Troubleshooting README and updating the links in the main README.